### PR TITLE
fix ChanelClose exception

### DIFF
--- a/cocotask/rabbitmq/common.py
+++ b/cocotask/rabbitmq/common.py
@@ -5,7 +5,7 @@ def createBlockingConnection(config):
 	parameters = pika.ConnectionParameters(config['SERVER_ADDRESS'],
 	                                   config['SERVER_PORT'],
 	                                   config.get("VIRTUAL_HOST", "/"),
-	                                   credentials)
+	                                   credentials, heartbeat_interval=0)
 	connection = pika.BlockingConnection(parameters)
 	channel = connection.channel()
 


### PR DESCRIPTION
When pika creates connecion without setting heartbeat_interval, rabbitmq server will use it's own interval in config file. If this value is too small, the connection may be broken by rabbitmq server when network is not stable or high delayed.
Now we set to 0, this means that the hearteat checking is disabled.
